### PR TITLE
Keep chest data safe across sessions

### DIFF
--- a/src/client/java/red/jackf/chesttracker/impl/memory/MemoryBankAccessImpl.java
+++ b/src/client/java/red/jackf/chesttracker/impl/memory/MemoryBankAccessImpl.java
@@ -1,8 +1,10 @@
 package red.jackf.chesttracker.impl.memory;
 
 import org.jetbrains.annotations.Nullable;
+import org.apache.logging.log4j.Logger;
 import red.jackf.chesttracker.api.memory.MemoryBank;
 import red.jackf.chesttracker.api.memory.MemoryBankAccess;
+import red.jackf.chesttracker.impl.ChestTracker;
 import red.jackf.chesttracker.impl.memory.metadata.Metadata;
 import red.jackf.chesttracker.impl.storage.ConnectionSettings;
 import red.jackf.chesttracker.impl.storage.GlobalMemoryBankDefaults;
@@ -14,6 +16,7 @@ import java.util.Optional;
 
 public class MemoryBankAccessImpl implements MemoryBankAccess {
     public static final MemoryBankAccessImpl INSTANCE = new MemoryBankAccessImpl();
+    private static final Logger LOGGER = ChestTracker.getLogger("MemoryBankAccess");
     @Nullable
     private static MemoryBankImpl loaded = null;
 
@@ -27,7 +30,10 @@ public class MemoryBankAccessImpl implements MemoryBankAccess {
     }
 
     public boolean loadOrCreate(String memoryBankId, String creationName, @Nullable Metadata defaultMetadata) {
-        INSTANCE.unload();
+        if (loaded != null && !INSTANCE.unload()) {
+            LOGGER.error("Keeping memory bank {} loaded because it could not be saved", loaded.getId());
+            return false;
+        }
         loaded = Storage.load(memoryBankId).orElseGet(() -> {
             var defaults = defaultMetadata == null ? GlobalMemoryBankDefaults.get() : defaultMetadata;
             var metadata = Metadata.fromDefaults(creationName, defaults, defaultMetadata == null || defaults.usesGlobalDefaults());
@@ -35,14 +41,44 @@ public class MemoryBankAccessImpl implements MemoryBankAccess {
             bank.setId(memoryBankId);
             return bank;
         });
-        INSTANCE.save();
+        if (loaded.getRegistryProvider() == null) {
+            loaded.setRegistryProvider(Storage.getCurrentRegistryProvider());
+        }
+        return INSTANCE.save();
+    }
 
+    /**
+     * Saves and reloads the current bank against the active registry set.
+     *
+     * <p>Some multiplayer proxies send another JOIN while keeping the same server address.
+     * The old bank must first be saved with its original registry provider, then decoded with
+     * the replacement provider before new container contents are added.</p>
+     */
+    public boolean reloadForRegistryChange() {
+        if (loaded == null) return false;
+
+        MemoryBankImpl previous = loaded;
+        if (!Storage.save(previous) || !Storage.waitForPendingSaves()) {
+            LOGGER.error("Could not save {} before a registry change; keeping the in-memory bank", previous.getId());
+            return false;
+        }
+
+        Optional<MemoryBankImpl> rebound = Storage.load(previous.getId());
+        if (rebound.isEmpty()) {
+            LOGGER.error("Could not reload {} after a registry change; keeping the in-memory bank", previous.getId());
+            return false;
+        }
+
+        loaded = rebound.get();
         return true;
     }
 
     public boolean unload() {
         if (loaded == null) return false;
-        save();
+        if (!save() || !Storage.waitForPendingSaves()) {
+            LOGGER.error("Could not unload memory bank {} because its save failed", loaded.getId());
+            return false;
+        }
         loaded = null;
         return true;
     }
@@ -56,9 +92,9 @@ public class MemoryBankAccessImpl implements MemoryBankAccess {
         return Optional.ofNullable(loaded);
     }
 
-    public void save() {
-        if (loaded == null) return;
-        Storage.save(loaded);
+    public boolean save() {
+        if (loaded == null) return false;
+        return Storage.save(loaded);
     }
 
     // Internal

--- a/src/client/java/red/jackf/chesttracker/impl/memory/MemoryBankImpl.java
+++ b/src/client/java/red/jackf/chesttracker/impl/memory/MemoryBankImpl.java
@@ -3,10 +3,12 @@ package red.jackf.chesttracker.impl.memory;
 import com.mojang.serialization.Codec;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import red.jackf.chesttracker.api.ClientBlockSource;
 import red.jackf.chesttracker.api.memory.Memory;
 import red.jackf.chesttracker.api.memory.MemoryBank;
@@ -35,6 +37,7 @@ public class MemoryBankImpl implements MemoryBank {
     private final Map<Identifier, MemoryKeyImpl> memoryKeys;
     private Metadata metadata;
     private String id;
+    private @Nullable HolderLookup.Provider registryProvider;
 
     public MemoryBankImpl(Metadata metadata, Map<Identifier, MemoryKeyImpl> keys) {
         this.metadata = metadata;
@@ -48,6 +51,22 @@ public class MemoryBankImpl implements MemoryBank {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    /**
+     * Returns the registry set that this bank's item stacks were decoded or captured with.
+     *
+     * <p>Dynamic registry holders are tied to their owning registry set. Multiplayer proxy
+     * transfers can replace the client's active registry set before the previous bank is
+     * saved, so using the current level's registries would make otherwise valid enchantments,
+     * trims, and other registry-backed components impossible to encode.</p>
+     */
+    public @Nullable HolderLookup.Provider getRegistryProvider() {
+        return registryProvider;
+    }
+
+    public void setRegistryProvider(@Nullable HolderLookup.Provider registryProvider) {
+        this.registryProvider = registryProvider;
     }
 
     public Metadata getMetadata() {

--- a/src/client/java/red/jackf/chesttracker/impl/providers/ProviderHandler.java
+++ b/src/client/java/red/jackf/chesttracker/impl/providers/ProviderHandler.java
@@ -9,6 +9,7 @@ import red.jackf.chesttracker.api.ClientBlockSource;
 import red.jackf.chesttracker.api.providers.InteractionTracker;
 import red.jackf.chesttracker.api.providers.context.BlockPlacedContext;
 import red.jackf.chesttracker.api.providers.ServerProvider;
+import red.jackf.chesttracker.impl.ChestTracker;
 import red.jackf.chesttracker.impl.events.AfterPlayerPlaceBlock;
 import red.jackf.chesttracker.impl.memory.MemoryBankAccessImpl;
 import red.jackf.chesttracker.impl.util.CachedClientBlockSource;
@@ -69,6 +70,13 @@ public class ProviderHandler {
                 if (!coord.get().equals(this.lastCoordinate)) {
                     this.lastCoordinate = coord.get();
                     this.load(coord.get());
+                } else {
+                    // Proxy transfers can replace dynamic registries without changing the
+                    // public server address. Rebind saved item holders before recording
+                    // contents from the new registry set.
+                    if (!MemoryBankAccessImpl.INSTANCE.reloadForRegistryChange()) {
+                        ChestTracker.LOGGER.error("Failed to rebind Chest Tracker storage after a registry change");
+                    }
                 }
             } else {
                 this.unload();

--- a/src/client/java/red/jackf/chesttracker/impl/storage/Storage.java
+++ b/src/client/java/red/jackf/chesttracker/impl/storage/Storage.java
@@ -3,15 +3,21 @@ package red.jackf.chesttracker.impl.storage;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.PauseScreen;
+import net.minecraft.ChatFormatting;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.network.chat.Component;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
 import red.jackf.chesttracker.impl.ChestTracker;
 import red.jackf.chesttracker.impl.config.ChestTrackerConfig;
 import red.jackf.chesttracker.impl.memory.MemoryBankAccessImpl;
 import red.jackf.chesttracker.impl.memory.MemoryBankImpl;
 import red.jackf.chesttracker.impl.memory.metadata.Metadata;
 import red.jackf.chesttracker.impl.storage.backend.Backend;
+import red.jackf.jackfredlib.client.api.toasts.ToastBuilder;
+import red.jackf.jackfredlib.client.api.toasts.ToastFormat;
+import red.jackf.jackfredlib.client.api.toasts.ToastIcon;
+import red.jackf.jackfredlib.client.api.toasts.Toasts;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -23,6 +29,8 @@ public class Storage {
     //////////////
 
     private static final Logger LOGGER = ChestTracker.getLogger("Storage");
+    private static final long SAVE_ERROR_TOAST_COOLDOWN_MS = 10_000L;
+    private static long lastSaveErrorToast;
     public static Backend backend;
 
     public static void setBackend(Backend backend) {
@@ -73,43 +81,65 @@ public class Storage {
         if (existing.isPresent() && id.equals(existing.get().getId()))
             return existing;
 
-        var level = Minecraft.getInstance().level;
-        HolderLookup.Provider registries = null;
-
-        if (level != null) {
-            registries = level.registryAccess();
-        }
+        HolderLookup.Provider registries = getCurrentRegistryProvider();
 
         LOGGER.debug("Loading {} using {}", id, backend.getClass().getSimpleName());
         var loaded = backend.load(id, registries);
         if (loaded == null) return Optional.empty();
         loaded.setId(id);
+        loaded.setRegistryProvider(registries);
         return Optional.of(loaded);
     }
 
-    public static void save(MemoryBankImpl bank) {
+    public static boolean save(MemoryBankImpl bank) {
         if (bank == null) {
             LOGGER.warn("Tried to save null Memory Bank");
-            return;
+            return false;
         }
 
-        var level = Minecraft.getInstance().level;
-        HolderLookup.Provider registries = null;
-
-        if (level != null) {
-            registries = level.registryAccess();
+        HolderLookup.Provider registries = bank.getRegistryProvider();
+        if (registries == null) {
+            registries = getCurrentRegistryProvider();
+            bank.setRegistryProvider(registries);
         }
 
         bank.getMetadata().updateModified();
-        backend.save(bank, registries);
+        boolean success = backend.save(bank, registries);
+        if (!success) {
+            reportSaveFailure(bank.getId());
+        }
+        return success;
+    }
+
+    public static boolean waitForPendingSaves() {
+        return backend.waitForPendingSaves();
+    }
+
+    public static @Nullable HolderLookup.Provider getCurrentRegistryProvider() {
+        var level = Minecraft.getInstance().level;
+        return level == null ? null : level.registryAccess();
+    }
+
+    public static synchronized void reportSaveFailure(String id) {
+        LOGGER.error("Failed to save memory bank {}", id);
+
+        long now = System.currentTimeMillis();
+        if (now - lastSaveErrorToast < SAVE_ERROR_TOAST_COOLDOWN_MS) return;
+        lastSaveErrorToast = now;
+
+        Minecraft.getInstance().execute(() ->
+                Toasts.INSTANCE.send(ToastBuilder.builder(ToastFormat.DARK, Component.translatable("chesttracker.title"))
+                        .withIcon(ToastIcon.modIcon(ChestTracker.ID))
+                        .addMessage(Component.translatable("chesttracker.storage.saveFailed", id).withStyle(ChatFormatting.RED))
+                        .progressShowsVisibleTime()
+                        .build()));
     }
 
     public static boolean saveMetadata(String id, Metadata metadata) {
         Optional<MemoryBankImpl> existing = MemoryBankAccessImpl.INSTANCE.getLoadedInternal();
         if (existing.isPresent() && id.equals(existing.get().getId())) {
             existing.get().setMetadata(metadata);
-            save(existing.get());
-            return true;
+            return save(existing.get());
         }
 
         metadata.updateModified();

--- a/src/client/java/red/jackf/chesttracker/impl/storage/backend/Backend.java
+++ b/src/client/java/red/jackf/chesttracker/impl/storage/backend/Backend.java
@@ -42,6 +42,17 @@ public interface Backend {
     boolean save(MemoryBankImpl memoryBank, @Nullable HolderLookup.Provider registries);
 
     /**
+     * Wait for any queued writes to finish and report whether they completed successfully.
+     *
+     * <p>Synchronous and in-memory backends have nothing to wait for.</p>
+     *
+     * @return Whether all pending writes completed successfully
+     */
+    default boolean waitForPendingSaves() {
+        return true;
+    }
+
+    /**
      * Returns a small label to show at the top of the "edit memory bank" screen.
      *
      * @param memoryBankId ID of a memory bank to generate a label for.

--- a/src/client/java/red/jackf/chesttracker/impl/storage/backend/JsonBackend.java
+++ b/src/client/java/red/jackf/chesttracker/impl/storage/backend/JsonBackend.java
@@ -16,6 +16,7 @@ import red.jackf.chesttracker.impl.config.ChestTrackerConfig;
 import red.jackf.chesttracker.impl.memory.MemoryBankImpl;
 import red.jackf.chesttracker.impl.memory.MemoryKeyImpl;
 import red.jackf.chesttracker.impl.memory.metadata.Metadata;
+import red.jackf.chesttracker.impl.storage.Storage;
 import red.jackf.chesttracker.impl.util.Constants;
 import red.jackf.chesttracker.impl.util.FileUtil;
 import red.jackf.chesttracker.impl.util.Misc;
@@ -26,6 +27,7 @@ import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -139,18 +141,6 @@ public class JsonBackend extends FileBasedBackend {
                             return false;
                         }
 
-                        // Save metadata
-                        if (!saveMetadata(id, metadataSnapshot)) {
-                            LOGGER.error("Failed to save metadata for {}", id);
-                            return false;
-                        }
-
-                        // Check for cancellation
-                        if (Thread.currentThread().isInterrupted()) {
-                            LOGGER.debug("Save for {} was cancelled during metadata save", id);
-                            return false;
-                        }
-
                         // Encode JSON data
                         LOGGER.debug("Encoding JSON data for {}", id);
                         Optional<JsonElement> memoryJson = MemoryBankImpl.DATA_CODEC
@@ -228,6 +218,12 @@ public class JsonBackend extends FileBasedBackend {
                             return false;
                         }
 
+                        // Commit metadata only after the data file has been replaced successfully.
+                        if (!saveMetadata(id, metadataSnapshot)) {
+                            LOGGER.error("Saved JSON data but failed to save metadata for {}", id);
+                            return false;
+                        }
+
                         LOGGER.debug("Successfully completed atomic save for {}", id);
 
                         // Delete old temporary files (if any remain from previous unsuccessful saves)
@@ -267,9 +263,10 @@ public class JsonBackend extends FileBasedBackend {
             pendingSavesJson.put(id, future);
 
             future.thenAccept(success -> {
-                pendingSavesJson.remove(id);
+                pendingSavesJson.remove(id, future);
                 if (!success) {
                     LOGGER.warn("JSON save failed for {}, data may be incomplete", id);
+                    Storage.reportSaveFailure(id);
                 } else {
                     LOGGER.debug("JSON successfully saved {} ({} entries)", id, entriesCount);
                 }
@@ -282,9 +279,6 @@ public class JsonBackend extends FileBasedBackend {
             DynamicOps<JsonElement> ops = registries == null ? JsonOps.INSTANCE : registries.createSerializationContext(JsonOps.INSTANCE);
 
             memoryBank.getMetadata().updateModified();
-            boolean metaSaveSuccess = saveMetadata(memoryBank.getId(), memoryBank.getMetadata());
-            if (!metaSaveSuccess) return false;
-
             Path path = Constants.STORAGE_DIR.resolve(memoryBank.getId() + extension());
 
             try {
@@ -293,7 +287,7 @@ public class JsonBackend extends FileBasedBackend {
                         .resultOrPartial(Util.prefix("Error encoding memories", LOGGER::error));
                 if (memoryJson.isPresent()) {
                     FileUtils.write(path.toFile(), FileUtil.gson().toJson(memoryJson.get()), StandardCharsets.UTF_8);
-                    return true;
+                    return saveMetadata(memoryBank.getId(), memoryBank.getMetadata());
                 } else {
                     LOGGER.error("Unknown error encoding memories for {}", memoryBank.getId());
                 }
@@ -306,23 +300,30 @@ public class JsonBackend extends FileBasedBackend {
     }
 
     // Waits for all active saves to complete if the game closes/the world
-    public void waitForPendingSaves() {
+    @Override
+    public boolean waitForPendingSaves() {
         if (pendingSavesJson.isEmpty()) {
             LOGGER.debug("No pending JSON saves to wait for");
-            return;
+            return true;
         }
         LOGGER.debug("Waiting for {} pending JSON save(s) to complete...", pendingSavesJson.size());
 
-        CompletableFuture<Void> allSaves = CompletableFuture.allOf(
-                pendingSavesJson.values().toArray(new CompletableFuture[0])
-        );
+        CompletableFuture<Boolean>[] saves = pendingSavesJson.values().toArray(new CompletableFuture[0]);
+        CompletableFuture<Void> allSaves = CompletableFuture.allOf(saves);
 
         try {
             // Waiting of 30 seconds in case of game freezing.
             allSaves.get(300, TimeUnit.SECONDS);
-            LOGGER.debug("All pending JSON saves completed");
+            boolean success = Arrays.stream(saves).allMatch(save -> Boolean.TRUE.equals(save.getNow(false)));
+            if (success) {
+                LOGGER.debug("All pending JSON saves completed");
+            } else {
+                LOGGER.error("One or more pending JSON saves failed");
+            }
+            return success;
         } catch (Exception ex) {
             LOGGER.error("Error or timeout waiting for JSON saves to complete", ex);
+            return false;
         }
     }
 }

--- a/src/client/java/red/jackf/chesttracker/impl/storage/backend/NbtBackend.java
+++ b/src/client/java/red/jackf/chesttracker/impl/storage/backend/NbtBackend.java
@@ -7,6 +7,7 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import red.jackf.chesttracker.impl.ChestTracker;
 import red.jackf.chesttracker.impl.memory.MemoryBankImpl;
+import red.jackf.chesttracker.impl.storage.Storage;
 import red.jackf.chesttracker.impl.util.Constants;
 import red.jackf.chesttracker.impl.util.FileUtil;
 import red.jackf.chesttracker.impl.util.Misc;
@@ -95,18 +96,6 @@ public class NbtBackend extends FileBasedBackend {
                             return false;
                         }
 
-                        // Save metadata
-                        if (!saveMetadata(id, metadataSnapshot)) {
-                            LOGGER.error("Failed to save metadata for {}", id);
-                            return false;
-                        }
-
-                        // Check for cancellation
-                        if (Thread.currentThread().isInterrupted()) {
-                            LOGGER.debug("Save for {} was cancelled during metadata save", id);
-                            return false;
-                        }
-
                         // Save NBT data to a temporary file
                         LOGGER.debug("Saving {} to temporary file: {}", id, tempFile.getFileName());
                         boolean saveSuccess = FileUtil.saveToNbt(
@@ -173,6 +162,12 @@ public class NbtBackend extends FileBasedBackend {
                             return false;
                         }
 
+                        // Commit metadata only after the data file has been replaced successfully.
+                        if (!saveMetadata(id, metadataSnapshot)) {
+                            LOGGER.error("Saved NBT data but failed to save metadata for {}", id);
+                            return false;
+                        }
+
                         LOGGER.debug("Successfully completed atomic save for {}", id);
 
                         // Delete old temporary files (if any remain from previous unsuccessful saves)
@@ -214,9 +209,10 @@ public class NbtBackend extends FileBasedBackend {
 
             // Remove from the map after completion
             future.thenAccept(success -> {
-                pendingSavesNbt.remove(id);
+                pendingSavesNbt.remove(id, future);
                 if (!success) {
                     LOGGER.warn("Save failed for {}, data may be incomplete", id);
+                    Storage.reportSaveFailure(id);
                 } else {
                     LOGGER.debug("Successfully saved {} ({} entries)", id, entriesCount);
                 }
@@ -225,29 +221,38 @@ public class NbtBackend extends FileBasedBackend {
         } else {
             LOGGER.debug("Saving {}", memoryBank.getId());
             memoryBank.getMetadata().updateModified();
-            if (!saveMetadata(memoryBank.getId(), memoryBank.getMetadata())) return false;
-            return FileUtil.saveToNbt(memoryBank.getMemories(), MemoryBankImpl.DATA_CODEC, Constants.STORAGE_DIR.resolve(memoryBank.getId() + extension()), registries);
+            if (!FileUtil.saveToNbt(memoryBank.getMemories(), MemoryBankImpl.DATA_CODEC, Constants.STORAGE_DIR.resolve(memoryBank.getId() + extension()), registries)) {
+                return false;
+            }
+            return saveMetadata(memoryBank.getId(), memoryBank.getMetadata());
         }
     }
 
     // Waits for all active saves to complete if the game closes/the world is exited
-    public void waitForPendingSaves() {
+    @Override
+    public boolean waitForPendingSaves() {
         if (pendingSavesNbt.isEmpty()) {
             LOGGER.debug("No pending saves to wait for");
-            return;
+            return true;
         }
         LOGGER.debug("Waiting for {} pending save(s) to complete...", pendingSavesNbt.size());
 
-        CompletableFuture<Void> allSaves = CompletableFuture.allOf(
-                pendingSavesNbt.values().toArray(new CompletableFuture[0])
-        );
+        CompletableFuture<Boolean>[] saves = pendingSavesNbt.values().toArray(new CompletableFuture[0]);
+        CompletableFuture<Void> allSaves = CompletableFuture.allOf(saves);
 
         try {
             // Waiting of 30 seconds in case of game freezing.
             allSaves.get(300, TimeUnit.SECONDS);
-            LOGGER.debug("All pending saves completed");
+            boolean success = Arrays.stream(saves).allMatch(save -> Boolean.TRUE.equals(save.getNow(false)));
+            if (success) {
+                LOGGER.debug("All pending saves completed");
+            } else {
+                LOGGER.error("One or more pending saves failed");
+            }
+            return success;
         } catch (Exception ex) {
             LOGGER.error("Error or timeout waiting for saves to complete", ex);
+            return false;
         }
     }
 

--- a/src/client/resources/assets/chesttracker/lang/en_us.json
+++ b/src/client/resources/assets/chesttracker/lang/en_us.json
@@ -17,6 +17,7 @@
   "chesttracker.inventoryButton.rememberContainer.block": "Don't Remember Container",
   "chesttracker.inventoryButton.export": "Export Position",
   "chesttracker.inventoryButton.export.toast": "Exported to %s",
+  "chesttracker.storage.saveFailed": "Could not save storage %s; keeping it in memory",
   "chesttracker.inventoryButton.export.errorToast": "Error exporting position; check the console.",
 
   "config.jade.plugin_chesttracker.memory_preview": "Use Memories",


### PR DESCRIPTION
This fixes an issue where chest data could disappear after leaving and rejoining a server, especially when connecting through a multiplayer proxy.

Some proxies send another join event for the same server while Minecraft is switching to a new dynamic registry set. Chest Tracker would then try to save the current memory bank with the new registries instead of the ones it was loaded with. Items containing registry-backed data, such as enchantments, could fail to serialize, leaving the storage file unusable the next time the player joined.

The fix keeps each loaded bank tied to its original registry provider. If the registry changes, Chest Tracker finishes saving the existing bank and waits for any pending writes before reloading it with the current registries. Only then does it begin accepting new container data.

While fixing this, I also tightened up the save path. Failed saves now leave the live bank in memory, asynchronous errors are reported properly, metadata is written only after the data file succeeds, and an older save callback can no longer clear a newer pending save. A throttled in-game notification also makes failures visible instead of allowing data loss to go unnoticed.