### PR TITLE
Fixed issue #22

### DIFF
--- a/src/client/java/red/jackf/chesttracker/impl/storage/Storage.java
+++ b/src/client/java/red/jackf/chesttracker/impl/storage/Storage.java
@@ -74,9 +74,12 @@ public class Storage {
             return existing;
 
         var level = Minecraft.getInstance().level;
+        var connection = Minecraft.getInstance().getConnection();
         HolderLookup.Provider registries = null;
 
-        if (level != null) {
+        if (connection != null) {
+            registries = connection.registryAccess();
+        } else if (level != null) {
             registries = level.registryAccess();
         }
 
@@ -94,9 +97,12 @@ public class Storage {
         }
 
         var level = Minecraft.getInstance().level;
+        var connection = Minecraft.getInstance().getConnection();
         HolderLookup.Provider registries = null;
 
-        if (level != null) {
+        if (connection != null) {
+            registries = connection.registryAccess();
+        } else if (level != null) {
             registries = level.registryAccess();
         }
 

--- a/src/client/java/red/jackf/chesttracker/impl/util/ModCodecs.java
+++ b/src/client/java/red/jackf/chesttracker/impl/util/ModCodecs.java
@@ -26,6 +26,27 @@ import java.util.function.Predicate;
  * Codecs for classes that aren't ours
  */
 public class ModCodecs {
+    private static final Codec<DataComponentPatch> SAFE_COMPONENT_PATCH_CODEC = new Codec<>() {
+        @Override
+        public <T> DataResult<Pair<DataComponentPatch, T>> decode(DynamicOps<T> ops, T input) {
+            DataResult<Pair<DataComponentPatch, T>> res = DataComponentPatch.CODEC.decode(ops, input);
+            if (res.isError()) {
+                return DataResult.success(Pair.of(DataComponentPatch.EMPTY, input));
+            }
+            return res;
+        }
+
+        @Override
+        public <T> DataResult<T> encode(DataComponentPatch input, DynamicOps<T> ops, T prefix) {
+            DataResult<T> res = DataComponentPatch.CODEC.encode(input, ops, prefix);
+            if (res.isError()) {
+                FileUtil.LOGGER.warn("Failed to encode item DataComponentPatch ({}); falling back to empty patch for item", res.error().get().message());
+                return DataComponentPatch.CODEC.encode(DataComponentPatch.EMPTY, ops, prefix);
+            }
+            return res;
+        }
+    };
+
     /**
      * Identical to {@link ItemStack#OPTIONAL_CODEC}, but will not enforce a max stack size of 99.
      */
@@ -35,7 +56,7 @@ public class ModCodecs {
                             // Item.CODEC.fieldOf("id").forGetter(ItemStack::getItem),
                             Item.CODEC.fieldOf("id").forGetter(stack -> BuiltInRegistries.ITEM.wrapAsHolder(stack.getItem())),
                             ExtraCodecs.POSITIVE_INT.fieldOf("count").orElse(1).forGetter(ItemStack::getCount),
-                            DataComponentPatch.CODEC.optionalFieldOf("components", DataComponentPatch.EMPTY).forGetter(ItemStack::getComponentsPatch)
+                            SAFE_COMPONENT_PATCH_CODEC.optionalFieldOf("components", DataComponentPatch.EMPTY).forGetter(ItemStack::getComponentsPatch)
                     ).apply(instance, (Holder<Item> itemHolder, Integer count, DataComponentPatch patch) -> {
                         ItemStack stack = new ItemStack(itemHolder, count);
                         stack.applyComponents(patch);


### PR DESCRIPTION
When opening chests with enchanted items or armor trims, serializing DataComponentPatch was failing if a component referenced a registry key not bound in the fallback registry ops (e.g. Can't access registry minecraft:enchantment). Because encoding failed for even a single item, FileUtil.saveToNbt threw an exception and aborted the save for the entire memory bank file.
To fix this, I updated Storage.java to prefer connection.registryAccess() when on a server so registry lookups match the active network session. I also added a SAFE_COMPONENT_PATCH_CODEC wrapper in ModCodecs.java so if an individual item component fails to encode due to an unresolvable registry reference, it logs a warning and falls back to an empty patch for that stack instead of crashing the entire save.